### PR TITLE
Support rubies < 2.1

### DIFF
--- a/lib/grub/gem_line.rb
+++ b/lib/grub/gem_line.rb
@@ -3,12 +3,13 @@ module Grub
 
     attr_accessor :name, :original_line, :location, :prev_line_comment, :spec, :options
 
-    def initialize(name:, original_line: nil, location: nil, prev_line_comment: nil, options: {})
-      @name = name
-      @original_line = original_line
-      @location = location
-      @prev_line_comment = prev_line_comment
-      @options = options
+    def initialize(*args)
+      named_params = args.last.respond_to?(:[]) && args.last
+      @name = (named_params && named_params[:name]) || args[0]
+      @original_line = (named_params && named_params[:original_line]) || args[1]
+      @location = (named_params && named_params[:location]) || args[2]
+      @prev_line_comment = (named_params && named_params[:prev_line_comment]) || args[3]
+      @options = (named_params && named_params[:options]) || named_params
     end
 
     def comment

--- a/test/grub/gem_line_test.rb
+++ b/test/grub/gem_line_test.rb
@@ -72,9 +72,7 @@ class Grub::GemLineTest < Minitest::Test
 
   def create_gem_line(options = {})
     Grub::GemLine.new(
-      name: "grub",
-      original_line: "gem 'grub'",
-      **options
+      { name: "grub", original_line: "gem 'grub'" }.merge(options)
     )
   end
 


### PR DESCRIPTION
Ruby 1.9 Doesn't have first-class keyword arguments for methods. And ruby 2.0 doesn't support required keyword arguments. 